### PR TITLE
Adding alt attribute to the images loaded for better WC3 validation

### DIFF
--- a/app/views/_knockout_assets.erb
+++ b/app/views/_knockout_assets.erb
@@ -17,7 +17,7 @@
 <% # Write out all the images hidden. This preloads them so templates show instantly  %>
 <% if preload
      asset_files.each { |k, v| %>
-        <img src="<%= v %>" style="display: none;"/>
+        <img src="<%= v %>" alt="<%= k %>" style="display: none;"/>
     <% }
        end
     %>


### PR DESCRIPTION
For better WC3 validation:
- An img element must have an alt attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.
