### PR TITLE
Add optional nonce support to script tag

### DIFF
--- a/app/helpers/knockout_assets.rb
+++ b/app/helpers/knockout_assets.rb
@@ -4,6 +4,7 @@ module KnockoutAssets
       exclude: nil,
       preload: true,
       include: /.*\.(png|gif|jpg|jpeg|bmp|svg)/,
+      nonce: nil,
     }.merge(options)
 
     files = {}
@@ -16,6 +17,6 @@ module KnockoutAssets
       }
     }
 
-    render :partial => '/knockout_assets', locals: {asset_files: files, preload: options[:preload]}
+    render :partial => '/knockout_assets', locals: {asset_files: files, preload: options[:preload], nonce: options[:nonce]}
   end
 end

--- a/app/views/_knockout_assets.erb
+++ b/app/views/_knockout_assets.erb
@@ -1,5 +1,5 @@
 <% # Prepare the asset hash and populate it  %>
-<script type="text/javascript">
+<script type="text/javascript"<% if nonce %> nonce="<%= nonce %>"<% end %>>
     var knockout_assets = {};
 
     <% asset_files.each { |k,v| %>


### PR DESCRIPTION
Adds an optional `nonce:` parameter to the `knockout_assets` helper, which is passed through to the `<script>` tag in the partial. This enables CSP (Content Security Policy) nonce support.

## Changes
- `knockout_assets` helper now accepts a `nonce:` option (defaults to `nil`)
- The partial renders `nonce="..."` on the `<script>` tag when a nonce is provided