### PR TITLE
Replace hidden image preloads with link rel=preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.0.7
+
+Replace hidden `<img>` preload tags with `<link rel="preload" as="image">` for better performance and cleaner DOM.
+
 ## Version 0.0.6
 
 Add the ability to specify a nonce.

--- a/app/views/_knockout_assets.erb
+++ b/app/views/_knockout_assets.erb
@@ -14,10 +14,10 @@
     };
 </script>
 
-<% # Write out all the images hidden. This preloads them so templates show instantly  %>
+<% # Preload images so templates show instantly when first rendered %>
 <% if preload
      asset_files.each { |k, v| %>
-        <img src="<%= v %>" alt="<%= k %>" style="display: none;"/>
+        <link rel="preload" href="<%= v %>" as="image"/>
     <% }
        end
     %>

--- a/lib/knockout/assets/version.rb
+++ b/lib/knockout/assets/version.rb
@@ -1,3 +1,3 @@
 module KnockoutAssets
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 end


### PR DESCRIPTION
   Previously, the `knockout_assets` helper emitted a hidden `<img style="display: none">`
   tag for every asset when `preload: true` - a legacy technique to warm the browser cache
   for images used in Knockout templates.

   This replaces those with `<link rel="preload" as="image">`, which is the modern equivalent.

   ## Why

   - **No DOM pollution** - removes dummy `<img>` elements from the document
   - **Better performance** - `<link rel="preload">` is processed by the browser's preload
     scanner before the HTML parser, so fetches start earlier
   - **Correct semantics** - explicitly signals fetch intent without rendering side-effects